### PR TITLE
Focus area titles change and CSS change for tab on leadership page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -87,7 +87,7 @@ primary_navigation:
       - name: Federal Data Strategy
         url: "/federal-data-strategy/"
       - name: COVID-19
-        url: "/COVID-19/"
+        url: "/covid-19/"
       - name: Data Skills Development
         url: "/data-skills-development/"
   - name: Guidance and Resources

--- a/_includes/exec-members.html
+++ b/_includes/exec-members.html
@@ -33,7 +33,7 @@
                 {% for bio in site.exec-members %}
                 <div class="tablet:grid-col-6 container padding-bottom-4">
                     <div class="clearfix shadow-5 radius-lg bg-white padding-2">
-                        <a style="color:black;text-decoration: none; display: block;" class="height-full" href="{{ site.baseurl }}{{ bio.permalink }}">
+                        <a style="color:black;text-decoration: none;" class="height-full" href="{{ site.baseurl }}{{ bio.permalink }}">
                             <div class="left">
                                 <img src="{{ site.baseurl }}/assets/images/members/{{ bio.bio-image }}" alt="{{bio.bio-image-alt-text }} portrait">
                             </div>

--- a/_includes/members.html
+++ b/_includes/members.html
@@ -5,7 +5,7 @@
             <div class="usa-graphic-list__row grid-row grid-gap padding-top-0">
                 {% for bio in site.members %}
                 <div class="tablet:grid-col-4 container" style="padding:10px;">
-                    <a style="color:black;text-decoration: none; display: block;" class="height-full" href="{{ site.baseurl }}{{ bio.permalink }}">
+                    <a style="color:black;text-decoration: none;" class="height-full" href="{{ site.baseurl }}{{ bio.permalink }}">
                         <div class="left">
                             <img src="{{ site.baseurl }}/assets/images/members/{{ bio.bio-image }}" alt="{{bio.bio-image-alt-text }} portrait">
                         </div>

--- a/_pages/Focus-Areas/covid-19.md
+++ b/_pages/Focus-Areas/covid-19.md
@@ -1,6 +1,6 @@
 ---
 title: Focus Area
-subtitle: COVID-19 Data Coordination Working Group
+subtitle: COVID-19 Data Coordination
 layout: defaultwithbanner
 sidenav: false
 permalink: /covid-19/

--- a/_pages/Focus-Areas/data-skills-development.md
+++ b/_pages/Focus-Areas/data-skills-development.md
@@ -1,6 +1,6 @@
 ---
 title: Focus Area
-subtitle: Data Skills Development Working Group
+subtitle: Data Skills Development
 layout: defaultwithbanner
 sidenav: false
 permalink: /data-skills-development/


### PR DESCRIPTION
Below 4 changes are included in this PR:
1. Blue focus box wrapped around the box when tabbed in Executive Members committee section.
2. Heading change of the COVID-19 page in Focus areas
3. Heading change of the Data skills development page in Focus Areas
4. COVID-19 404 error fix
