### PR TITLE
updated link appearance

### DIFF
--- a/_pages/programs-and-events/symposium-2024.html
+++ b/_pages/programs-and-events/symposium-2024.html
@@ -17,7 +17,7 @@ permalink: /2024-cdo-council-symposium/
                     <strong>Time:</strong> 8:00 AM to 3:30 PM ET <br>
                     <strong>Location:</strong> GSA Auditorium at 1800 F St NW, Washington, DC, 20405, Floor 1, Wing 0 <br>
                     <strong>Who:</strong> Leaders from across the federal government from a diverse group of mission functions (CDOs, CFOs, CIOs, CHCOs, etc.) and other parties who use federal data (industry, academia, etc.)<br>
-                    <strong>Registration:</strong> <a href="https://www.ticketsource.us/whats-on/dc/gsa-general-services-administration/federal-cdo-council-presents-data-powers-mission-transforming-business-and-mission-with-data/2024-11-21/08:00/t-vvopglp?direct-booking">https://www.ticketsource.us/whats-on/dc/gsa-general-services-administration/federal-cdo-council-presents-data-powers-mission-transforming-business-and-mission-with-data/2024-11-21/08:00/t-vvopglp?direct-booking</a>
+                    <a href="https://www.ticketsource.us/whats-on/dc/gsa-general-services-administration/federal-cdo-council-presents-data-powers-mission-transforming-business-and-mission-with-data/2024-11-21/08:00/t-vvopglp?direct-booking"><strong>Register Here</strong></a>
                     
                 </span>
             </div>


### PR DESCRIPTION
**Request Description**
_Original_
On the CDOC Symposium Event Page (https://www.cdo.gov/2024-cdo-council-symposium/) please remove "Registration link coming soon. Questions? Contact the Federal CDO Council at cdocstaff@gsa.gov" and add a hyperlink for the event registration from "https://www.ticketsource.us/whats-on/dc/gsa-general-services-administration/federal-cdo-council-presents-data-powers-mission-transforming-business-and-mission-with-data/2024-11-21/08:00/t-vvopglp?direct-booking"
_Update_
Instead of listing the full registration link as originally requested, can we change the “Registration” title to a hyperlinked “Register Here” button?

**Preview Link**
https://federalist-f1b28fce-2346-4571-9c87-af81641dafe3.sites.pages.cloud.gov/preview/gsa/cdoc/feature/RITM1253276/2024-cdo-council-symposium/