### PR TITLE
added goals link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -81,6 +81,8 @@ primary_navigation:
         url: "/about-us/"
       - name: About Chief Data Officers
         url: "/about-agency-cdos/"
+      - name: Council Goals
+        url: "/about-us/#2024-2025-cdo-council-goals"
   - name: Members
     children:
       - name: Council Leadership


### PR DESCRIPTION
**[Preview](https://federalist-f1b28fce-2346-4571-9c87-af81641dafe3.sites.pages.cloud.gov/preview/gsa/cdoc/feature/RITM1274687/)**

**Description**
On the CDO.gov page (https://www.cdo.gov/), please add a link under the "About" drop down labeled "Council Goals". If possible, we would like the new link to take users directly to "2024-2025 CDO Council Goals" that are housed under the "About the Council" (https://www.cdo.gov/about-us/). 

Note: We do not want them to have to scroll down to find it, but rather once they click the new drop down under "About" and "Council Goals", we want it to take them directly to the goals.